### PR TITLE
wiki: updated certification related APIs

### DIFF
--- a/API/20240222-api-specification.md
+++ b/API/20240222-api-specification.md
@@ -495,7 +495,7 @@ $ http POST :8000/refresh Authorization:"Bearer $REFRESH_TOKEN"
 #### 기본 정보
 | method | request URL          | format | description |
 |--------|----------------------|--------|-------------|
-|POST    |{base-url}/certifications | JSON | S3에 업로드된 이미지 URL 전송 |
+|PATCH    |{base-url}/certifications | JSON | S3에 업로드된 이미지 URL 전송 |
 
 #### 요청 변수
 

--- a/API/20240222-api-specification.md
+++ b/API/20240222-api-specification.md
@@ -429,6 +429,8 @@ $ http POST :8000/refresh Authorization:"Bearer $REFRESH_TOKEN"
 |------|------|----------|-------------|
 | boxId | Int | Y | - 쪽지가 담긴 상자의 id |
 
+- 쿼리 파라미터로 전달
+
 #### 요청 헤더
 
 - Authorization 에 Bearer 토큰

--- a/API/20240222-api-specification.md
+++ b/API/20240222-api-specification.md
@@ -488,19 +488,19 @@ $ http POST :8000/refresh Authorization:"Bearer $REFRESH_TOKEN"
 
 ## 증명서
 
-### 사진 업로드하기
+### 사진 URL 업로드하기
 
 #### 기본 정보
 | method | request URL          | format | description |
 |--------|----------------------|--------|-------------|
-|POST    |{base-url}/certifications | JSON | 증명서에 첨부될 사진 업로드하기 |
+|POST    |{base-url}/certifications | JSON | S3에 업로드된 이미지 URL 전송 |
 
 #### 요청 변수
 
 | name | type | required | description |
 |------|------|----------|-------------|
 | boxId | Int | Y | - 증명서에 해당하는 선물상자 ID |
-| image | String | Y | - 증명서에 첨부될 사진 <br> - Base64 인코딩 필요 |
+| imageUrl | String | Y | - 증명서에 첨부될 사진 URL <br> - S3 버킷에 업로드 |
 
 #### 요청 헤더
 
@@ -522,16 +522,20 @@ $ http POST :8000/refresh Authorization:"Bearer $REFRESH_TOKEN"
 }
 ```
 
-### 증명서 정보 가져오기
+### 증명서 이미지 가져오기
 
 #### 기본 정보
 | method | request URL          | format | description |
 |--------|----------------------|--------|-------------|
-|GET    |{base-url}/certifications/{box-id} | JSON | 증명서에 들어갈 내용 가져오기 |
+|GET    |{base-url}/certifications | JSON | 증명서에 들어갈 내용 가져오기 |
 
 #### 요청 변수
 
-- 없음
+| name | type | required | description |
+|------|------|----------|-------------|
+| boxId | Int | Y | - 증명서에 해당하는 선물상자 ID |
+
+- 쿼리 파라미터로 전달
 
 #### 요청 헤더
 

--- a/API/20240222-api-specification.md
+++ b/API/20240222-api-specification.md
@@ -556,7 +556,7 @@ $ http POST :8000/refresh Authorization:"Bearer $REFRESH_TOKEN"
 		"boxCreatedBy": "권은빈",
 		"donorsNameList": ["박민주", "복예린", ...],
 		"certImgUrl": "s3_image_url",
-		"certCreatedAt": "20240124",
+		"certCreatedAt": "2024-01-24",
 	}
 }
 
@@ -567,7 +567,7 @@ $ http POST :8000/refresh Authorization:"Bearer $REFRESH_TOKEN"
 }
 ```
 
-- certCreatedAt 타입 Datetime, KST, YYYYMMDD
+- certCreatedAt 타입 String yyyy-mm-dd
 
 # References
 


### PR DESCRIPTION
- 증명 이미지를 FE에서 저장하게 되어 s3에 업로드된 이미지 url을 PATCH하는 것으로 변경했습니다.
- messages GET API와의 통일성을 위해 certifications GET API에 필요한 boxId를 쿼리 파라미터로 받도록 변경했습니다.
- messages GET API에 빠진 내용을 추가했습니다.
- certifications GET API에서 증명서가 만들어진 날짜의 타입과 형식을 변경했습니다.
  - **AS IS**: Datetime, yyyymmdd | **TO BE**: String, yyyy-mm-dd